### PR TITLE
claude 4 opus thinking option

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,11 +16,15 @@
     "lint-staged": "16.1.2",
     "prettier": "^3.6.2",
     "syncpack": "^13.0.4",
-    "turbo": "^2.5.3",
+    "tsup": "^8.5.0",
+    "turbo": "^2.5.4",
     "typescript": "5.8.3"
   },
   "packageManager": "pnpm@9.0.0",
   "engines": {
     "node": ">=20"
+  },
+  "dependencies": {
+    "@dotenvx/dotenvx": "^1.47.3"
   }
 }

--- a/perplexity/extension/src/services/cplx-api/remote-resources/pplx-language-models/defaults.ts
+++ b/perplexity/extension/src/services/cplx-api/remote-resources/pplx-language-models/defaults.ts
@@ -20,7 +20,7 @@ export const pplxLocalLanguageModels = [
   {
     label: "Claude 4 Opus",
     shortLabel: "Opus Thinking",
-    code: "claude4opusthinking",
+    code: "claude40opusthinking",
     provider: "Anthropic",
     limitKey: "gpt4_limit",
     type: "reasoning",

--- a/perplexity/extension/src/services/cplx-api/remote-resources/pplx-language-models/defaults.ts
+++ b/perplexity/extension/src/services/cplx-api/remote-resources/pplx-language-models/defaults.ts
@@ -18,6 +18,15 @@ export const pplxLocalLanguageModels = [
     hideFromList: false,
   },
   {
+    label: "Claude 4 Opus",
+    shortLabel: "Opus Thinking",
+    code: "claude4opusthinking",
+    provider: "Anthropic",
+    limitKey: "gpt4_limit",
+    type: "reasoning",
+    hideFromList: false,
+  },
+  {
     label: "Gemini 2.5 Pro",
     shortLabel: "Gemini Pro",
     code: "gemini2flash",


### PR DESCRIPTION
The value of "model_preference" for claude 4.0 opus thinking, observed in the request payload in the browser, is "claude40opusthinking".

I apologize that I don't know enough about the build process setup to test this.

I'm glad to help however I can.

