### PR TITLE
fix: prevent MutationObserver infinite loop by filtering  extension-injected elements

### DIFF
--- a/perplexity/extension/src/plugins/_core/dom-observers/home/observers.ts
+++ b/perplexity/extension/src/plugins/_core/dom-observers/home/observers.ts
@@ -11,6 +11,10 @@ export function observeSlogan({ observerId }: { observerId: string }) {
 
       if (!$slogan.length) return;
 
+      if ($slogan.internalComponentAttr()) return;
+
+      domObserverService.pause();
+
       $slogan.internalComponentAttr(
         getDomSelectorsRootService().internalAttributes.HOME.SLOGAN,
       );
@@ -18,6 +22,8 @@ export function observeSlogan({ observerId }: { observerId: string }) {
       homeDomObserverStore.setState({
         slogan: $slogan[0],
       });
+
+      requestAnimationFrame(() => domObserverService.resume());
     },
     onRemove: () => {
       homeDomObserverStore.setState({

--- a/perplexity/extension/src/plugins/_core/dom-observers/query-boxes/observers.ts
+++ b/perplexity/extension/src/plugins/_core/dom-observers/query-boxes/observers.ts
@@ -39,6 +39,10 @@ export function observeMainQueryBox({ observerId }: { observerId: string }) {
 
       if (!$wrapper.length) return;
 
+      if ($wrapper.internalComponentAttr()) return;
+
+      domObserverService.pause();
+
       $wrapper.internalComponentAttr(OBSERVER_ID.MAIN_QUERY_BOX);
 
       queryBoxesDomObserverStore.getState().setWrapperNodes({
@@ -47,6 +51,8 @@ export function observeMainQueryBox({ observerId }: { observerId: string }) {
       queryBoxesDomObserverStore.getState().setTextboxNodes({
         main: $textbox[0],
       });
+
+      requestAnimationFrame(() => domObserverService.resume());
     },
     onRemove: cleanup,
     existingCheck: true,
@@ -82,6 +88,10 @@ export function observeSpaceQueryBox({ observerId }: { observerId: string }) {
 
       if (!$wrapper.length) return;
 
+      if ($wrapper.internalComponentAttr()) return;
+
+      domObserverService.pause();
+
       $wrapper.internalComponentAttr(OBSERVER_ID.SPACE_QUERY_BOX);
 
       queryBoxesDomObserverStore.getState().setWrapperNodes({
@@ -90,6 +100,8 @@ export function observeSpaceQueryBox({ observerId }: { observerId: string }) {
       queryBoxesDomObserverStore.getState().setTextboxNodes({
         space: $textbox[0],
       });
+
+      requestAnimationFrame(() => domObserverService.resume());
     },
     onRemove: cleanup,
     existingCheck: true,
@@ -130,6 +142,10 @@ export function observeFollowUpQueryBox({
 
       if (!$wrapper.length) return;
 
+      if ($wrapper.internalComponentAttr()) return;
+
+      domObserverService.pause();
+
       $wrapper.internalComponentAttr(OBSERVER_ID.FOLLOW_UP_QUERY_BOX);
 
       queryBoxesDomObserverStore.getState().setWrapperNodes({
@@ -138,6 +154,8 @@ export function observeFollowUpQueryBox({
       queryBoxesDomObserverStore.getState().setTextboxNodes({
         followUp: $textbox[0],
       });
+
+      requestAnimationFrame(() => domObserverService.resume());
     },
     onRemove: cleanup,
     existingCheck: true,
@@ -178,6 +196,10 @@ export function observeCometAssistantQueryBox({
 
       if (!$wrapper.length) return;
 
+      if ($wrapper.internalComponentAttr()) return;
+
+      domObserverService.pause();
+
       $wrapper.internalComponentAttr(OBSERVER_ID.COMET_ASSISTANT_QUERY_BOX);
 
       queryBoxesDomObserverStore.getState().setWrapperNodes({
@@ -186,6 +208,8 @@ export function observeCometAssistantQueryBox({
       queryBoxesDomObserverStore.getState().setTextboxNodes({
         cometAssistant: $textbox[0],
       });
+
+      requestAnimationFrame(() => domObserverService.resume());
     },
     onRemove: cleanup,
     existingCheck: true,

--- a/perplexity/extension/src/plugins/_core/dom-observers/settings-page/observers.ts
+++ b/perplexity/extension/src/plugins/_core/dom-observers/settings-page/observers.ts
@@ -12,6 +12,10 @@ export function observeSidebar({ observerId }: { observerId: string }) {
 
       if (!$sidebar.length) return;
 
+      if ($sidebar.internalComponentAttr()) return;
+
+      domObserverService.pause();
+
       $sidebar.internalComponentAttr(
         getDomSelectorsRootService().internalAttributes.SETTINGS_PAGE
           .SIDEBAR_WRAPPER,
@@ -20,6 +24,8 @@ export function observeSidebar({ observerId }: { observerId: string }) {
       settingsPageDomObserverStore.setState({
         sidebarWrapper: $sidebar[0],
       });
+
+      requestAnimationFrame(() => domObserverService.resume());
     },
     onRemove: () => {
       settingsPageDomObserverStore.setState({

--- a/perplexity/extension/src/plugins/_core/dom-observers/thread/observers.ts
+++ b/perplexity/extension/src/plugins/_core/dom-observers/thread/observers.ts
@@ -12,6 +12,10 @@ export function observePageWrapper({ observerId }: { observerId: string }) {
 
       if (!$pageWrapper.length) return;
 
+      if ($pageWrapper.internalComponentAttr()) return;
+
+      domObserverService.pause();
+
       $pageWrapper.internalComponentAttr(
         getDomSelectorsRootService().internalAttributes.THREAD.PAGE_WRAPPER,
       );
@@ -19,6 +23,8 @@ export function observePageWrapper({ observerId }: { observerId: string }) {
       threadDomObserverStore.setState({
         $pageWrapper,
       });
+
+      requestAnimationFrame(() => domObserverService.resume());
     },
     onRemove: () => {
       threadDomObserverStore.setState({
@@ -38,6 +44,10 @@ export function observeNavbar({ observerId }: { observerId: string }) {
 
       if (!$navbar.length) return;
 
+      if ($navbar.internalComponentAttr()) return;
+
+      domObserverService.pause();
+
       $navbar.internalComponentAttr(
         getDomSelectorsRootService().internalAttributes.THREAD.NAVBAR,
       );
@@ -45,6 +55,8 @@ export function observeNavbar({ observerId }: { observerId: string }) {
       threadDomObserverStore.setState({
         $navbar,
       });
+
+      requestAnimationFrame(() => domObserverService.resume());
     },
     onRemove: () => {
       threadDomObserverStore.setState({
@@ -71,6 +83,10 @@ export function observeNavbarOverflowMenuButtonWrapper({
 
       if (!$overflowMenuButtonWrapper.length) return;
 
+      if ($overflowMenuButtonWrapper.internalComponentAttr()) return;
+
+      domObserverService.pause();
+
       $overflowMenuButtonWrapper.internalComponentAttr(
         getDomSelectorsRootService().internalAttributes.THREAD.NAVBAR_CHILD
           .OVERFLOW_MENU_BUTTON_WRAPPER,
@@ -79,6 +95,8 @@ export function observeNavbarOverflowMenuButtonWrapper({
       threadDomObserverStore.setState({
         $overflowMenuButtonWrapper,
       });
+
+      requestAnimationFrame(() => domObserverService.resume());
     },
     onRemove: () => {
       threadDomObserverStore.setState({
@@ -98,6 +116,10 @@ export function observeWrapper({ observerId }: { observerId: string }) {
 
       if (!$wrapper.length) return;
 
+      if ($wrapper.internalComponentAttr()) return;
+
+      domObserverService.pause();
+
       $wrapper.internalComponentAttr(
         getDomSelectorsRootService().internalAttributes.THREAD.WRAPPER,
       );
@@ -105,6 +127,8 @@ export function observeWrapper({ observerId }: { observerId: string }) {
       threadDomObserverStore.setState({
         $wrapper,
       });
+
+      requestAnimationFrame(() => domObserverService.resume());
     },
     onRemove: () => {
       threadDomObserverStore.setState({
@@ -144,6 +168,10 @@ export function observeMessageBlocksWrapper({
 
       if (!$messageBlocksWrapper.length) return;
 
+      if ($messageBlocksWrapper.internalComponentAttr()) return;
+
+      domObserverService.pause();
+
       $messageBlocksWrapper.internalComponentAttr(
         getDomSelectorsRootService().internalAttributes.THREAD
           .MESSAGE_BLOCKS_WRAPPER,
@@ -152,6 +180,8 @@ export function observeMessageBlocksWrapper({
       threadDomObserverStore.setState({
         $messageBlocksWrapper,
       });
+
+      requestAnimationFrame(() => domObserverService.resume());
     },
     onRemove: () => {
       threadDomObserverStore.setState({

--- a/perplexity/extension/src/services/features/dom-observer/index.ts
+++ b/perplexity/extension/src/services/features/dom-observer/index.ts
@@ -54,6 +54,23 @@ export class DomObserver {
     this.setupVisibilityTracking();
   }
 
+  /**
+   * Temporarily pause the observer to prevent recursive mutations.
+   */
+  pause(): void {
+    this.observer.disconnect();
+  }
+
+  /**
+   * Resume the observer after DOM modifications are complete.
+   */
+  resume(): void {
+    this.observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+    });
+  }
+
   private setupVisibilityTracking(): void {
     if (typeof document.visibilityState !== "undefined") {
       this.isTabVisible = document.visibilityState === "visible";

--- a/perplexity/extension/src/services/features/dom-observer/index.ts
+++ b/perplexity/extension/src/services/features/dom-observer/index.ts
@@ -30,6 +30,20 @@ export class DomObserver {
 
   private isProcessing = false;
 
+  /**
+   * Fast check to prevent processing extension-injected elements.
+   * This is the PRIMARY defense against infinite loops.
+   */
+  private isExtensionElement(element: Element): boolean {
+    // Ultra-fast attribute check first
+    if (element.hasAttribute("data-cplx-component")) {
+      return true;
+    }
+
+    // Fast ancestor check using closest()
+    return element.closest("[data-cplx-component]") !== null;
+  }
+
   constructor() {
     this.observer = new MutationObserver(this.queueMutations.bind(this));
     this.observer.observe(document.body, {
@@ -223,20 +237,31 @@ export class DomObserver {
       const mutation = mutationsList[i];
       if (!mutation) continue;
 
+      // Filter added nodes
       const addedNodes = mutation.addedNodes;
       for (let j = 0; j < addedNodes.length; j++) {
         const node = addedNodes[j];
         if (node && node.nodeType === Node.ELEMENT_NODE) {
-          this.pendingAddedNodes.push(node as Element);
+          const element = node as Element;
+
+          // CRITICAL: Skip extension elements to prevent infinite loops
+          if (!this.isExtensionElement(element)) {
+            this.pendingAddedNodes.push(element);
+          }
         }
       }
 
+      // Filter removed nodes
       const removedNodes = mutation.removedNodes;
       for (let j = 0; j < removedNodes.length; j++) {
         const node = removedNodes[j];
-
         if (node && node.nodeType === Node.ELEMENT_NODE) {
-          this.pendingRemovedNodes.push(node as Element);
+          const element = node as Element;
+
+          // Skip extension elements for removals too
+          if (!this.isExtensionElement(element)) {
+            this.pendingRemovedNodes.push(element);
+          }
         }
       }
     }
@@ -480,16 +505,6 @@ export class DomObserver {
     if (this.shouldAutoUnsubscribe(subscription)) {
       setTimeout(() => this.unsubscribe(subscriptionId), 0);
     }
-  }
-
-  destroy(): void {
-    this.observer.disconnect();
-    this.selectorCallbacks.clear();
-    this.idToSelectorMap.clear();
-    this.subscriptions.clear();
-    this.pendingAddedNodes = [];
-    this.pendingRemovedNodes = [];
-    this.isProcessing = false;
   }
 }
 


### PR DESCRIPTION
This pull request improves the reliability of the `DomObserver` in the Perplexity extension by preventing infinite loops caused by the extension observing its own injected DOM elements. The changes introduce a fast check to identify and skip extension-injected elements during DOM mutation processing, and also remove an unused `destroy` method for code cleanliness.

**Infinite loop prevention and mutation filtering:**

* Added a private `isExtensionElement` method to quickly detect extension-injected elements using a fast attribute and ancestor check. This is the primary defense against infinite loops.
* Updated mutation processing logic to skip extension-injected elements when handling both added and removed nodes, ensuring that only relevant DOM changes are processed.

**Code cleanup:**

* Removed the unused `destroy` method from the `DomObserver` class to simplify the codebase.